### PR TITLE
Add concurrency controls and deduplication to IP list workflows

### DIFF
--- a/.github/workflows/TorExit.yml
+++ b/.github/workflows/TorExit.yml
@@ -8,6 +8,13 @@ on:
 permissions:
   contents: write
 
+# Alle Workflows die in IP.txt schreiben teilen sich diese Gruppe, damit sie
+# niemals gleichzeitig laufen. Sonst lesen zwei Jobs dieselbe IP.txt und der
+# zweite Push überschreibt den ersten -> Duplikate / Konflikte.
+concurrency:
+  group: ip-txt-update
+  cancel-in-progress: false
+
 jobs:
   update-tor-exits:
     runs-on: self-hosted
@@ -44,21 +51,41 @@ jobs:
         run: |
           touch IP.txt
 
-          # Alte Tor-Einträge entfernen
-          grep -v "# TorExit$" IP.txt > ip_clean.txt || true
+          # 1) Alte TorExit-Einträge entfernen -> Basis
+          grep -v "# TorExit$" IP.txt > ip_base.txt || true
 
-          # Neue Tor Exit Nodes mit Kommentar anhängen
-          while read -r ip; do
-            echo "$ip  # TorExit"
-          done < tor_ips.txt >> ip_clean.txt
+          # 2) Alle bereits in der Basis vorhandenen IPs (andere Quellen + manuell)
+          grep -v '^#' ip_base.txt \
+            | grep -oE '([0-9]{1,3}\.){3}[0-9]{1,3}' \
+            | sort -u \
+            > existing_ips.txt
 
-          mv ip_clean.txt IP.txt
+          # 3) Nur Tor-IPs anhängen, die noch von KEINER anderen Quelle stammen
+          NEW_IPS=$(comm -23 <(sort -u tor_ips.txt) existing_ips.txt)
+          NEW_COUNT=$(echo "$NEW_IPS" | grep -c . || true)
+          SKIPPED=$(comm -12 <(sort -u tor_ips.txt) existing_ips.txt | wc -l)
 
-          COUNT=$(wc -l < tor_ips.txt)
-          echo "Replaced old TorExit entries with $COUNT fresh IPs"
+          if [ -n "$NEW_IPS" ] && [ "$NEW_COUNT" -gt 0 ]; then
+            while read -r ip; do
+              echo "$ip  # TorExit"
+            done <<< "$NEW_IPS" >> ip_base.txt
+          fi
+
+          # 4) Globaler Dedup: erste Nennung einer IP gewinnt, Kommentarzeilen bleiben
+          awk '
+            /^[[:space:]]*#/ { print; next }
+            match($0, /[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/) {
+              ip = substr($0, RSTART, RLENGTH)
+              if (!(ip in seen)) { seen[ip] = 1; print }
+              next
+            }
+            { print }
+          ' ip_base.txt > IP.txt
+
+          echo "TorExit: $NEW_COUNT neu, $SKIPPED bereits vorhanden (übersprungen)"
 
       - name: Cleanup temp files
-        run: rm -f tor_raw.txt tor_ips.txt
+        run: rm -f tor_raw.txt tor_ips.txt ip_base.txt existing_ips.txt
 
       - name: Commit & Push if changed
         run: |

--- a/.github/workflows/VPN-Gate.yml
+++ b/.github/workflows/VPN-Gate.yml
@@ -8,6 +8,13 @@ on:
 permissions:
   contents: write
 
+# Alle Workflows die in IP.txt schreiben teilen sich diese Gruppe, damit sie
+# niemals gleichzeitig laufen. Sonst lesen zwei Jobs dieselbe IP.txt und der
+# zweite Push überschreibt den ersten -> Duplikate / Konflikte.
+concurrency:
+  group: ip-txt-update
+  cancel-in-progress: false
+
 jobs:
   update-vpngate:
     runs-on: self-hosted
@@ -46,21 +53,41 @@ jobs:
         run: |
           touch IP.txt
 
-          # Alle alten VPNGate-Zeilen entfernen (Zeilen die mit "# VPNGate" enden)
-          grep -v "# VPNGate$" IP.txt > ip_clean.txt || true
+          # 1) Alte VPNGate-Einträge entfernen -> Basis
+          grep -v "# VPNGate$" IP.txt > ip_base.txt || true
 
-          # Neue VPNGate IPs mit Kommentar anhängen
-          while read -r ip; do
-            echo "$ip  # VPNGate"
-          done < vpngate_ips.txt >> ip_clean.txt
+          # 2) Alle bereits in der Basis vorhandenen IPs (andere Quellen + manuell)
+          grep -v '^#' ip_base.txt \
+            | grep -oE '([0-9]{1,3}\.){3}[0-9]{1,3}' \
+            | sort -u \
+            > existing_ips.txt
 
-          mv ip_clean.txt IP.txt
+          # 3) Nur VPNGate-IPs anhängen, die noch von KEINER anderen Quelle stammen
+          NEW_IPS=$(comm -23 <(sort -u vpngate_ips.txt) existing_ips.txt)
+          NEW_COUNT=$(echo "$NEW_IPS" | grep -c . || true)
+          SKIPPED=$(comm -12 <(sort -u vpngate_ips.txt) existing_ips.txt | wc -l)
 
-          COUNT=$(wc -l < vpngate_ips.txt)
-          echo "Replaced old VPNGate entries with $COUNT fresh IPs"
+          if [ -n "$NEW_IPS" ] && [ "$NEW_COUNT" -gt 0 ]; then
+            while read -r ip; do
+              echo "$ip  # VPNGate"
+            done <<< "$NEW_IPS" >> ip_base.txt
+          fi
+
+          # 4) Globaler Dedup: erste Nennung einer IP gewinnt, Kommentarzeilen bleiben
+          awk '
+            /^[[:space:]]*#/ { print; next }
+            match($0, /[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/) {
+              ip = substr($0, RSTART, RLENGTH)
+              if (!(ip in seen)) { seen[ip] = 1; print }
+              next
+            }
+            { print }
+          ' ip_base.txt > IP.txt
+
+          echo "VPNGate: $NEW_COUNT neu, $SKIPPED bereits vorhanden (übersprungen)"
 
       - name: Cleanup temp files
-        run: rm -f vpngate_raw.csv vpngate_ips.txt
+        run: rm -f vpngate_raw.csv vpngate_ips.txt ip_base.txt existing_ips.txt
 
       - name: Commit & Push if changed
         run: |

--- a/.github/workflows/asn-lists.yml
+++ b/.github/workflows/asn-lists.yml
@@ -8,6 +8,11 @@ on:
 permissions:
   contents: write
 
+# Serialisiert ASN.txt-Läufe, damit sich parallele Runs nicht überschreiben.
+concurrency:
+  group: asn-txt-update
+  cancel-in-progress: false
+
 jobs:
   update-asn:
     runs-on: self-hosted

--- a/.github/workflows/other-proxy-apis.yml
+++ b/.github/workflows/other-proxy-apis.yml
@@ -8,6 +8,13 @@ on:
 permissions:
   contents: write
 
+# Alle Workflows die in IP.txt schreiben teilen sich diese Gruppe, damit sie
+# niemals gleichzeitig laufen. Sonst lesen zwei Jobs dieselbe IP.txt und der
+# zweite Push überschreibt den ersten -> Duplikate / Konflikte.
+concurrency:
+  group: ip-txt-update
+  cancel-in-progress: false
+
 jobs:
   update-proxies:
     runs-on: self-hosted
@@ -101,7 +108,17 @@ jobs:
             done <<< "$NEW_IPS" >> /tmp/ip_clean.txt
           fi
 
-          mv /tmp/ip_clean.txt IP.txt
+          # Globaler Dedup: erste Nennung einer IP gewinnt, Kommentarzeilen bleiben.
+          # Sicherheitsnetz, falls die Quelldatei bereits Altlast-Duplikate enthält.
+          awk '
+            /^[[:space:]]*#/ { print; next }
+            match($0, /[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/) {
+              ip = substr($0, RSTART, RLENGTH)
+              if (!(ip in seen)) { seen[ip] = 1; print }
+              next
+            }
+            { print }
+          ' /tmp/ip_clean.txt > IP.txt
 
           # --- Duplikat-Report ---
           DUPLICATES_FOUND=$(comm -12 \


### PR DESCRIPTION
## Summary
This PR adds concurrency controls across all IP list update workflows and implements global deduplication logic to prevent race conditions and duplicate entries in the IP.txt file.

## Key Changes

- **Concurrency Groups**: Added `concurrency` configuration to all workflows that write to IP.txt (TorExit, VPN-Gate, other-proxy-apis) and ASN.txt (asn-lists) to serialize execution and prevent simultaneous writes that could cause data loss or conflicts.

- **Deduplication Logic**: Implemented a global deduplication mechanism using `awk` in three workflows (TorExit, VPN-Gate, other-proxy-apis) that:
  - Preserves comment lines (lines starting with `#`)
  - Extracts IP addresses from each line
  - Keeps only the first occurrence of each IP address
  - Maintains the original order and formatting

- **Source-Aware IP Addition**: Enhanced IP filtering logic to:
  - Extract existing IPs from the base file (from all sources)
  - Only add new IPs that don't already exist from other sources
  - Track and report how many IPs were skipped (already present) vs. newly added
  - Prevent duplicate IPs across different proxy sources

- **Improved Logging**: Updated status messages to show both new IPs added and skipped IPs, providing better visibility into what changed.

- **Cleanup**: Extended temporary file cleanup to include new intermediate files (ip_base.txt, existing_ips.txt).

## Implementation Details

The deduplication uses an `awk` script that maintains a `seen` array to track processed IPs. This ensures that even if the source data or previous runs contained duplicates, the final IP.txt file will have each IP listed only once, with the first occurrence (and its associated source comment) preserved.

The concurrency groups use `cancel-in-progress: false` to ensure workflows complete sequentially rather than canceling in-progress runs, maintaining data integrity during updates.

https://claude.ai/code/session_01L7i2gsVEUeUtdQCcx84GAE